### PR TITLE
feat: include 0 in y limits for plot_indices()

### DIFF
--- a/R/plot_indices.R
+++ b/R/plot_indices.R
@@ -64,7 +64,8 @@ plot_indices <- function(data,
     ) +
     ggplot2::scale_colour_viridis_d() +
     ggplot2::xlab("Year") +
-    ggplot2::ylab("Index (mt)")
+    ggplot2::ylab("Index (mt)") +
+    ggplot2::expand_limits(y = 0)
 
   ggplot2::ggsave(
     plot = gg,


### PR DESCRIPTION
Tiny change to include 0 in vertical axis for `plot_indices()`

Makes the difference between panel on left and that on the right which were created by the following commands before and after the change, where the left panel makes the increase seem much more dramatic if you don't pay attention to the axis (it's a dramatic increase either way).
```
dir <- "\\\\nwcfile/FRAM/Assessments/CurrentAssessments/petrale_2023/data/wcgbts"
load(file.path(dir, "delta_gamma/index/sdmTMB_save.RData"))
index_areas %>% dplyr::filter(area == "coastwide") %>% plot_indices()
```

![image](https://user-images.githubusercontent.com/4992918/228980498-0db91939-c324-4d5a-903c-b6a07bea6ca8.png)
