### PR TITLE
Update configuration.csv for petrale to delta_lognormal

### DIFF
--- a/data-raw/configuration.csv
+++ b/data-raw/configuration.csv
@@ -1,5 +1,5 @@
 species,fxn,source,family,formula,min_depth,max_depth,min_latitude,max_latitude,min_year,max_year,anisotropy
-"petrale sole","nwfscSurvey::pull_catch(common_name = species,survey=source)","NWFSC.Combo",sdmTMB::delta_lognormal_mix(),"catch_weight ~ 0 + fyear + pass_scaled",-55,-675,-Inf,Inf,-Inf,Inf,TRUE
+"petrale sole","nwfscSurvey::pull_catch(common_name = species,survey=source)","NWFSC.Combo",sdmTMB::delta_lognormal(),"catch_weight ~ 0 + fyear + pass_scaled",-55,-675,-Inf,Inf,-Inf,Inf,TRUE
 "petrale sole","nwfscSurvey::pull_catch(common_name = species,survey=source)","Triennial",sdmTMB::delta_lognormal(),"catch_weight ~ 0 + fyear + s(depth_scaled)",-55,-366,37,Inf,-Inf,Inf,TRUE
 "canary rockfish","nwfscSurvey::pull_catch(common_name = species,survey=source)","NWFSC.Combo",sdmTMB::delta_lognormal,"catch_weight ~ 0 + fyear + pass_scaled",-55,-275,-Inf,Inf,-Inf,Inf,FALSE
 "canary rockfish","nwfscSurvey::pull_catch(common_name = species,survey=source)","Triennial",sdmTMB::delta_lognormal_mix(),"catch_weight ~ 0 + fyear",-55,-366,37,Inf,-Inf,Inf,FALSE


### PR DESCRIPTION
## **What was changed/addressed**
The delta_lognormal distribution produces the same trend but different scale than the delta_lognormal_mix.
@kellijohnson-NOAA, this is updating the configuration.csv file to reflect the change in chosen distribution.

## **Additional information**
Comparison below shows very similar trend but different scale and different uncertainty (where the blue line represents the delta_lognormal_mix (est, lwr, and upr values) multiplied by 4.84 which is the ratio of the mean index under the different distributions.
![index_comparisons_WCGBTS_11-May-2023](https://github.com/kellijohnson-NOAA/indexwc/assets/4992918/68e65361-4178-40ac-bc3f-6af0da78d809)
